### PR TITLE
[hotfix] 2.1.0.6 - Added Method to repair defense mods for Jedi

### DIFF
--- a/MMOCoreORB/bin/scripts/object/building/general/space_dungeon_star_destroyer.lua
+++ b/MMOCoreORB/bin/scripts/object/building/general/space_dungeon_star_destroyer.lua
@@ -42,7 +42,52 @@
 
 
 object_building_general_space_dungeon_star_destroyer = object_building_general_shared_space_dungeon_star_destroyer:new {
-
+  planetMapCategory = "cloningfacility",
+  
+    skillMods = {
+      {"private_medical_rating", 100}
+          },
+  
+          childObjects = {
+                {templateFile = "object/tangible/terminal/terminal_insurance.iff", x = -10.5816, z = 175.335, y = -35.5272, ox = 0, oy = 0, oz = 0, ow = 1, cellid = 33, containmentType = -1},
+                 
+            -- Elevator Terminals
+              -- Docking Control
+                {templateFile = "object/tangible/terminal/terminal_elevator_up.iff", x = 48.9897, z = 173.835, y = 205.563, ox = 0, oy = -0.707107, oz = 0, ow = 0.707107, cellid = 39, containmentType = -1},              
+                {templateFile = "object/tangible/terminal/terminal_elevator_down.iff", x = 48.9897, z = 192.335, y = 205.563, ox = 0, oy = -0.707107, oz = 0, ow = 0.707107, cellid = 39, containmentType = -1},
+                
+              -- Port Side Hangar 
+                {templateFile = "object/tangible/terminal/terminal_elevator_up.iff", x = 54.3956, z = 173.835, y = 20.1421, ox = 0, oy = -0.707107, oz = 0, ow = 0.707107, cellid = 37, containmentType = -1},              
+                {templateFile = "object/tangible/terminal/terminal_elevator_down.iff", x = 54.3956, z = 181.335, y = 20.1421, ox = 0, oy = -0.707107, oz = 0, ow = 0.707107, cellid = 37, containmentType = -1},
+              -- Starboard Side Hangar 
+                {templateFile = "object/tangible/terminal/terminal_elevator_up.iff", x = -54.3932, z = 173.835, y = 20.1421, ox = 0, oy = -0.707107, oz = 0, ow = -0.707107, cellid = 38, containmentType = -1},              
+                {templateFile = "object/tangible/terminal/terminal_elevator_down.iff", x = -54.3932, z = 181.335, y = 20.1421, ox = 0, oy = -0.707107, oz = 0, ow = -0.707107, cellid = 38, containmentType = -1},
+              -- Reactor Lift
+                  -- Disabled due to bugged cells on that level.
+                {templateFile = "object/tangible/terminal/terminal_elevator_up.iff", x = 20.0514, z = 140.585, y = 347.689, ox = 0, oy = 0, oz = 0, ow = -1, cellid = 40, containmentType = -1},              
+                {templateFile = "object/tangible/terminal/terminal_elevator_down.iff", x = 20.0514, z = 170.585, y = 347.689, ox = 0, oy = 0, oz = 0, ow = -1, cellid = 40, containmentType = -1},
+                --]]
+              -- Bridge Lift
+                {templateFile = "object/tangible/terminal/terminal_elevator_up.iff", x = 19.9312, z = 170.585, y = 430.471, ox = 0, oy = 0, oz = 0, ow = 1, cellid = 48, containmentType = -1},              
+                {templateFile = "object/tangible/terminal/terminal_elevator_down.iff", x = 19.9312, z = 453.359, y = 430.471, ox = 0, oy = 0, oz = 0, ow = 1, cellid = 48, containmentType = -1},
+                -- Port Side bridge 
+                {templateFile = "object/tangible/terminal/terminal_elevator_up.iff", x = 21.3, z = 448.607, y = 341.889, ox = 0, oy = -0.707107, oz = 0, ow = 0.707107, cellid = 55, containmentType = -1},              
+                {templateFile = "object/tangible/terminal/terminal_elevator_down.iff", x = 21.3, z = 453.609, y = 341.889, ox = 0, oy = -0.707107, oz = 0, ow = 0.707107, cellid = 55, containmentType = -1},
+              -- Starboard Side bridge 
+                {templateFile = "object/tangible/terminal/terminal_elevator_up.iff", x = -21.399, z = 448.607, y = 341.889, ox = 0, oy = 0.707107, oz = 0, ow = 0.707107, cellid = 56, containmentType = -1},              
+                {templateFile = "object/tangible/terminal/terminal_elevator_down.iff", x = -21.399, z = 453.609, y = 341.889, ox = 0, oy = 0.707107, oz = 0, ow = 0.707107, cellid = 56, containmentType = -1},
+                 
+          
+          
+          
+         },
+  
+    spawningPoints = {
+      { x = -7.75978, z = 175.522, y = -34.3437, ow = 0.897693, ox = 0, oz = 0, oy = -0.440621, cellid = 33 }
+      }, -- { x, z, y, ow, ox, oy, oz, cellid }
+  templateType = CLONINGBUILDING,
+  facilityType = CLONER_STANDARD, 
+ 
 }
 
 ObjectTemplates:addTemplate(object_building_general_space_dungeon_star_destroyer, "object/building/general/space_dungeon_star_destroyer.iff")

--- a/MMOCoreORB/bin/scripts/object/tangible/terminal/terminal_character_builder.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/terminal/terminal_character_builder.lua
@@ -1549,14 +1549,15 @@ object_tangible_terminal_terminal_character_builder = object_tangible_terminal_s
 					"Master", "crafting_weaponsmith_master"
 				}
 			},
-			"Unlearn All Skills", "unlearn_all_skills",
+			"Unlearn All Skills", "unlearn_all_skills",			
 			"Cleanse Character", "cleanse_character",
 			"Enhance Character", "enhance_character",
 			"Jedi",
 			{
 				"Unlock Jedi Initiate", "unlock_jedi_initiate",
 				"Unlock FRS Light Side", "frs_light_side",
-				"Unlock FRS Dark Side", "frs_dark_side"
+				"Unlock FRS Dark Side", "frs_dark_side",
+				"Reset Defense Modifiers (UNEQUIP ROBE FIRST!)", "reset_defense_mods",
 			},
 			"Fill Force Bar", "fill_force_bar",
 			"Reset Buffs", "reset_buffs",

--- a/MMOCoreORB/bin/scripts/object/tangible/terminal/terminal_character_builder.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/terminal/terminal_character_builder.lua
@@ -1557,7 +1557,7 @@ object_tangible_terminal_terminal_character_builder = object_tangible_terminal_s
 				"Unlock Jedi Initiate", "unlock_jedi_initiate",
 				"Unlock FRS Light Side", "frs_light_side",
 				"Unlock FRS Dark Side", "frs_dark_side",
-				"Reset Defense Modifiers (UNEQUIP ROBE FIRST!)", "reset_defense_mods",
+			--	"Reset Defense Modifiers (UNEQUIP ROBE FIRST!)", "reset_defense_mods",
 			},
 			"Fill Force Bar", "fill_force_bar",
 			"Reset Buffs", "reset_buffs",

--- a/MMOCoreORB/bin/scripts/object/tangible/terminal/terminal_character_builder.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/terminal/terminal_character_builder.lua
@@ -1557,7 +1557,7 @@ object_tangible_terminal_terminal_character_builder = object_tangible_terminal_s
 				"Unlock Jedi Initiate", "unlock_jedi_initiate",
 				"Unlock FRS Light Side", "frs_light_side",
 				"Unlock FRS Dark Side", "frs_dark_side",
-			--	"Reset Defense Modifiers (UNEQUIP ROBE FIRST!)", "reset_defense_mods",
+				"Reset Defense Modifiers (UNEQUIP ROBE FIRST!)", "reset_defense_mods",
 			},
 			"Fill Force Bar", "fill_force_bar",
 			"Reset Buffs", "reset_buffs",

--- a/MMOCoreORB/bin/scripts/object/weapon/ranged/vehicle/vehicle_atst_ranged.lua
+++ b/MMOCoreORB/bin/scripts/object/weapon/ranged/vehicle/vehicle_atst_ranged.lua
@@ -54,7 +54,7 @@ object_weapon_ranged_vehicle_vehicle_atst_ranged = object_weapon_ranged_vehicle_
 	damageType = ENERGY,
 
 	-- NONE, LIGHT, MEDIUM, HEAVY
-	armorPiercing = HEAVY,
+	armorPiercing = LIGHT,
 
 	xpType = "combat_general",
 

--- a/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
@@ -300,7 +300,7 @@ void SuiManager::handleCharacterBuilderSelectItem(CreatureObject* player, SuiBox
 						player->sendSystemMessage("Not within combat.");
 					}
 				}
-			} else if (templatePath == "reset_defense_mods") {
+		/*	} else if (templatePath == "reset_defense_mods") {
 				if (ghost->isJedi()) {
 					if (!player->isInCombat()) {
 						player->sendSystemMessage("You reset your Melee and Ranged Defense Modifiers.");
@@ -319,7 +319,7 @@ void SuiManager::handleCharacterBuilderSelectItem(CreatureObject* player, SuiBox
 					} else {
 						player->sendSystemMessage("Not within combat.");
 					}
-				}
+				} */
 			} else if (templatePath == "reset_buffs") {
 				if (!player->isInCombat()) {
 					player->sendSystemMessage("Your buffs have been reset.");

--- a/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
@@ -300,26 +300,22 @@ void SuiManager::handleCharacterBuilderSelectItem(CreatureObject* player, SuiBox
 						player->sendSystemMessage("Not within combat.");
 					}
 				}
-		/*	} else if (templatePath == "reset_defense_mods") {
+		} else if (templatePath == "reset_defense_mods") {
 				if (ghost->isJedi()) {
 					if (!player->isInCombat()) {
 						player->sendSystemMessage("You reset your Melee and Ranged Defense Modifiers.");
 
-						if (ghost->hasSkill("force_sensitive_enhanced_reflexes_ranged_defense_04")){
-							ghost->setSkillModifier(SkillModManager::PERMANENTMOD, "ranged_defense", 20, true);
-						} else{
-							ghost->setSkillModifier(SkillModManager::PERMANENTMOD, "ranged_defense", 0, true);
+						if (player->hasSkill("force_sensitive_enhanced_reflexes_ranged_defense_04")){
+							player->addSkillMod(SkillModManager::SKILLBOX, "ranged_defense", 90, true);
 						}
-						if (ghost->hasSkill("force_sensitive_enhanced_reflexes_melee_defense_04")){
-							ghost->setSkillModifier(SkillModManager::PERMANENTMOD, "melee_defense", 20, true);
-						} else{
-							ghost->setSkillModifier(SkillModManager::PERMANENTMOD, "melee_defense", 0, true);
+						if (player->hasSkill("force_sensitive_enhanced_reflexes_melee_defense_04")){
+							player->addSkillMod(SkillModManager::SKILLBOX, "melee_defense", 90, true);
 						}
 
 					} else {
 						player->sendSystemMessage("Not within combat.");
 					}
-				} */
+				}
 			} else if (templatePath == "reset_buffs") {
 				if (!player->isInCombat()) {
 					player->sendSystemMessage("Your buffs have been reset.");

--- a/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
@@ -300,6 +300,26 @@ void SuiManager::handleCharacterBuilderSelectItem(CreatureObject* player, SuiBox
 						player->sendSystemMessage("Not within combat.");
 					}
 				}
+			} else if (templatePath == "reset_defense_mods") {
+				if (ghost->isJedi()) {
+					if (!player->isInCombat()) {
+						player->sendSystemMessage("You reset your Melee and Ranged Defense Modifiers.");
+
+						if (player->hasSkill("force_sensitive_enhanced_reflexes_ranged_defense_04")){
+							player->setSkillModifier(SkillModManager::PERMANENTMOD, "ranged_defense", 20, true);
+						} else{
+							player->setSkillModifier(SkillModManager::PERMANENTMOD, "ranged_defense", 0, true);
+						}
+						if (player->hasSkill("force_sensitive_enhanced_reflexes_melee_defense_04")){
+							player->setSkillModifier(SkillModManager::PERMANENTMOD, "melee_defense", 20, true);
+						} else{
+							player->setSkillModifier(SkillModManager::PERMANENTMOD, "melee_defense", 0, true);
+						}
+
+					} else {
+						player->sendSystemMessage("Not within combat.");
+					}
+				}
 			} else if (templatePath == "reset_buffs") {
 				if (!player->isInCombat()) {
 					player->sendSystemMessage("Your buffs have been reset.");

--- a/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
@@ -301,17 +301,28 @@ void SuiManager::handleCharacterBuilderSelectItem(CreatureObject* player, SuiBox
 					}
 				}
 		} else if (templatePath == "reset_defense_mods") {
+				int curRangedD = 0, curMeleeD = 0;
+				
 				if (ghost->isJedi()) {
 					if (!player->isInCombat()) {
 						player->sendSystemMessage("You reset your Melee and Ranged Defense Modifiers.");
-
+	
 						if (player->hasSkill("force_sensitive_enhanced_reflexes_ranged_defense_04")){
+							curRangedD = player->getSkillMod("ranged_defense");
+						if (curRangedD < 0) {
 							player->addSkillMod(SkillModManager::SKILLBOX, "ranged_defense", 90, true);
+						} else {
+							player->sendSystemMessage("Your ranged defense has already been normalised.");
+						}
 						}
 						if (player->hasSkill("force_sensitive_enhanced_reflexes_melee_defense_04")){
+							curMeleeD = player->getSkillMod("melee_defense");
+						if (curMeleeD < 0) {
 							player->addSkillMod(SkillModManager::SKILLBOX, "melee_defense", 90, true);
+						} else {
+							player->sendSystemMessage("Your melee defense has already been normalised.");
 						}
-
+						}
 					} else {
 						player->sendSystemMessage("Not within combat.");
 					}

--- a/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
@@ -312,7 +312,11 @@ void SuiManager::handleCharacterBuilderSelectItem(CreatureObject* player, SuiBox
 						if (curRangedD < 0) {
 							player->addSkillMod(SkillModManager::SKILLBOX, "ranged_defense", 90, true);
 						} else {
+							if (curRangedD >= 110){
+								player->addSkillMod(SkillModManager::SKILLBOX, "ranged_defense", -90, true);
+							} else {
 							player->sendSystemMessage("Your ranged defense has already been normalised.");
+							}
 						}
 						}
 						if (player->hasSkill("force_sensitive_enhanced_reflexes_melee_defense_04")){
@@ -320,7 +324,11 @@ void SuiManager::handleCharacterBuilderSelectItem(CreatureObject* player, SuiBox
 						if (curMeleeD < 0) {
 							player->addSkillMod(SkillModManager::SKILLBOX, "melee_defense", 90, true);
 						} else {
+							if (curMeleeD >= 110) {
+								player->addSkillMod(SkillModManager::SKILLBOX, "melee_defense", -90, true);
+							} else{
 							player->sendSystemMessage("Your melee defense has already been normalised.");
+							}
 						}
 						}
 					} else {

--- a/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/sui/SuiManager.cpp
@@ -305,15 +305,15 @@ void SuiManager::handleCharacterBuilderSelectItem(CreatureObject* player, SuiBox
 					if (!player->isInCombat()) {
 						player->sendSystemMessage("You reset your Melee and Ranged Defense Modifiers.");
 
-						if (player->hasSkill("force_sensitive_enhanced_reflexes_ranged_defense_04")){
-							player->setSkillModifier(SkillModManager::PERMANENTMOD, "ranged_defense", 20, true);
+						if (ghost->hasSkill("force_sensitive_enhanced_reflexes_ranged_defense_04")){
+							ghost->setSkillModifier(SkillModManager::PERMANENTMOD, "ranged_defense", 20, true);
 						} else{
-							player->setSkillModifier(SkillModManager::PERMANENTMOD, "ranged_defense", 0, true);
+							ghost->setSkillModifier(SkillModManager::PERMANENTMOD, "ranged_defense", 0, true);
 						}
-						if (player->hasSkill("force_sensitive_enhanced_reflexes_melee_defense_04")){
-							player->setSkillModifier(SkillModManager::PERMANENTMOD, "melee_defense", 20, true);
+						if (ghost->hasSkill("force_sensitive_enhanced_reflexes_melee_defense_04")){
+							ghost->setSkillModifier(SkillModManager::PERMANENTMOD, "melee_defense", 20, true);
 						} else{
-							player->setSkillModifier(SkillModManager::PERMANENTMOD, "melee_defense", 0, true);
+							ghost->setSkillModifier(SkillModManager::PERMANENTMOD, "melee_defense", 0, true);
 						}
 
 					} else {

--- a/MMOCoreORB/src/server/zone/objects/intangible/PetControlDeviceImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/intangible/PetControlDeviceImplementation.cpp
@@ -229,7 +229,7 @@ void PetControlDeviceImplementation::callObject(CreatureObject* player) {
 		Reference<CallPetTask*> callPet = new CallPetTask(_this.getReferenceUnsafeStaticCast(), player, "call_pet");
 
 		StringIdChatParameter message("pet/pet_menu", "call_pet_delay"); // Calling pet in %DI seconds. Combat will terminate pet call.
-		message.setDI(15);
+		message.setDI(5);
 		player->sendSystemMessage(message);
 
 		player->addPendingTask("call_pet", callPet, 5 * 1000);


### PR DESCRIPTION
Should a character have an issue related to stat mods on robes, this new blue frog addition will correct stats to where they should be.