### PR TITLE
[Update] Force Armor duration.

### DIFF
--- a/MMOCoreORB/bin/scripts/commands/forceArmor1.lua
+++ b/MMOCoreORB/bin/scripts/commands/forceArmor1.lua
@@ -44,7 +44,7 @@
 ForceArmor1Command = {
     name = "forcearmor1",
     forceCost = 5,
-    duration = 900,
+    duration = 12600,
     --animationCRC = hashCode()
     clientEffect = "clienteffect/pl_force_armor_self.cef",
     buffClass = SINGLE_USE_BUFF,

--- a/MMOCoreORB/bin/scripts/commands/forceArmor2.lua
+++ b/MMOCoreORB/bin/scripts/commands/forceArmor2.lua
@@ -44,7 +44,7 @@
 ForceArmor2Command = {
     name = "forcearmor2",
     forceCost = 8,
-    duration = 1800,
+    duration = 12600,
     --animationCRC = hashCode()
     clientEffect = "clienteffect/pl_force_armor_self.cef",
     buffClass = SINGLE_USE_BUFF,


### PR DESCRIPTION
FA1 & FA2 to last 3.5 hours to coincide with buffs.

Note : It will still be removed if you go down to 0 force.